### PR TITLE
Delayed message support

### DIFF
--- a/broker/rabbitmq/channel.go
+++ b/broker/rabbitmq/channel.go
@@ -60,27 +60,27 @@ func (r *rabbitMQChannel) Publish(exchange, key string, message amqp.Publishing)
 	return r.channel.Publish(exchange, key, false, false, message)
 }
 
-func (r *rabbitMQChannel) DeclareExchange(exchange string) error {
+func (r *rabbitMQChannel) DeclareExchange(exchange string, kind string, args amqp.Table) error {
 	return r.channel.ExchangeDeclare(
 		exchange, // name
-		"topic",  // kind
+		kind,  // kind
 		false,    // durable
 		false,    // autoDelete
 		false,    // internal
 		false,    // noWait
-		nil,      // args
+		args,      // args
 	)
 }
 
-func (r *rabbitMQChannel) DeclareDurableExchange(exchange string) error {
+func (r *rabbitMQChannel) DeclareDurableExchange(exchange string, kind string, args amqp.Table) error {
 	return r.channel.ExchangeDeclare(
 		exchange, // name
-		"topic",  // kind
+		kind,  // kind
 		true,     // durable
 		false,    // autoDelete
 		false,    // internal
 		false,    // noWait
-		nil,      // args
+		args,      // args
 	)
 }
 

--- a/broker/rabbitmq/connection.go
+++ b/broker/rabbitmq/connection.go
@@ -17,6 +17,8 @@ import (
 var (
 	DefaultExchange = Exchange{
 		Name: "micro",
+		Kind: "topic",
+		Args: nil,
 	}
 	DefaultRabbitURL      = "amqp://guest:guest@127.0.0.1:5672"
 	DefaultPrefetchCount  = 0
@@ -61,6 +63,10 @@ type Exchange struct {
 	Name string
 	// Whether its persistent
 	Durable bool
+
+	Kind string
+
+	Args amqp.Table
 }
 
 func newRabbitMQConn(ex Exchange, urls []string, prefetchCount int, prefetchGlobal bool) *rabbitMQConn {
@@ -209,9 +215,9 @@ func (r *rabbitMQConn) tryConnect(secure bool, config *amqp.Config) error {
 	}
 
 	if r.exchange.Durable {
-		r.Channel.DeclareDurableExchange(r.exchange.Name)
+		r.Channel.DeclareDurableExchange(r.exchange.Name,r.exchange.Kind,r.exchange.Args)
 	} else {
-		r.Channel.DeclareExchange(r.exchange.Name)
+		r.Channel.DeclareExchange(r.exchange.Name,r.exchange.Kind,r.exchange.Args)
 	}
 	r.ExchangeChannel, err = newRabbitChannel(r.Connection, r.prefetchCount, r.prefetchGlobal)
 


### PR DESCRIPTION
Use cases

rabbitmqDelay.DefaultRabbitURL = os.Getenv("RABBIT_URL")
	args := make(amqp.Table)
	args["x-delayed-type"] = "direct"
	rabbitmqDelay.DefaultExchange = rabbitmqDelay.Exchange{Name: exchangeDelay, Kind: "x-delayed-message", Args: args}
	DelayBroker := rabbitmqDelay.NewBroker(rabbitmqDelay.DurableExchange())

Publish

body, _ := proto.Marshal(resp.ExamRecord)
	if err := DelayBroker.Publish(AutomaticHandingInTopic, &broker.Message{
		Header: map[string]string{"x-delay":"60000"},
		Body: body,
	}, rabbitmqDelay.DeliveryMode(2)); err != nil {
		resp.Error = &pb.Error{Description: err.Error()}
	}
