### PR TITLE
replace github.com/coreos/etcd with go.etcd.io/etcd

### DIFF
--- a/registry/etcd/etcd.go
+++ b/registry/etcd/etcd.go
@@ -13,9 +13,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/coreos/etcd/clientv3"
-	"github.com/coreos/etcd/etcdserver/api/v3rpc/rpctypes"
-	"github.com/coreos/etcd/mvcc/mvccpb"
+	"go.etcd.io/etcd/clientv3"
+	"go.etcd.io/etcd/etcdserver/api/v3rpc/rpctypes"
+	"go.etcd.io/etcd/mvcc/mvccpb"
+
 	"github.com/micro/go-micro/v3/logger"
 	"github.com/micro/go-micro/v3/registry"
 	hash "github.com/mitchellh/hashstructure"


### PR DESCRIPTION
github.com/coreos/etcd is deprecated