### PR TITLE
replace github.com/coreos/etcd with go.etcd.io/etcd

### DIFF
--- a/registry/etcd/watcher.go
+++ b/registry/etcd/watcher.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/coreos/etcd/clientv3"
+	"go.etcd.io/etcd/clientv3"
 	"github.com/micro/go-micro/v3/registry"
 )
 


### PR DESCRIPTION
github.com/coreos/etcd is deprecated